### PR TITLE
feat: Add mux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ krakend
 krakend-alpine
 cmd/krakend-integration/krakend-integration
 tests/fixtures/krakend.json.final
+.idea

--- a/backend_factory.go
+++ b/backend_factory.go
@@ -10,7 +10,7 @@ import (
 	lambda "github.com/devopsfaith/krakend-lambda"
 	lua "github.com/devopsfaith/krakend-lua/proxy"
 	"github.com/devopsfaith/krakend-martian"
-	metrics "github.com/devopsfaith/krakend-metrics/gin"
+	metrics "github.com/devopsfaith/krakend-metrics/mux"
 	"github.com/devopsfaith/krakend-oauth2-clientcredentials"
 	opencensus "github.com/devopsfaith/krakend-opencensus"
 	pubsub "github.com/devopsfaith/krakend-pubsub"

--- a/executor.go
+++ b/executor.go
@@ -3,6 +3,8 @@ package krakend
 import (
 	"context"
 	"fmt"
+	httpsecure "github.com/devopsfaith/krakend-httpsecure/mux"
+	lua "github.com/devopsfaith/krakend-lua/router/mux"
 	"io"
 	"net/http"
 	"os"
@@ -160,6 +162,9 @@ func (e *ExecutorBuilder) NewCmdExecutor(ctx context.Context) cmd.Executor {
 		if err != nil {
 			logger.Warning("bloomFilter:", err.Error())
 		}
+
+		e.Middlewares = lua.RegisterMiddleware(logger, cfg.ExtraConfig, httptreemux.ParamsExtractor, e.Middlewares)
+		e.Middlewares = append(e.Middlewares, httpsecure.NewSecureMw(cfg.ExtraConfig))
 
 		// setup the krakend router
 		routerFactory := router.NewFactory(router.Config{

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/devopsfaith/krakend-usage v0.0.0-20181025134340-476779c0a36c
 	github.com/devopsfaith/krakend-viper v0.0.0-20200605164302-854fa4ff4a66
 	github.com/devopsfaith/krakend-xml v0.0.0-20200824111110-baa61b333b05
+	github.com/dimfeld/httptreemux v5.0.1+incompatible
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-contrib/uuid v1.2.0
 	github.com/google/btree v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -646,6 +646,7 @@ github.com/dimchansky/utfbom v1.1.0 h1:FcM3g+nofKgUteL8dm/UpdRXNC9KmADgTpLKsu0TR
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi/U=
 github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
+github.com/dimfeld/httptreemux v5.0.1+incompatible h1:Qj3gVcDNoOthBAqftuD596rm4wg/adLLz5xh5CmpiCA=
 github.com/dimfeld/httptreemux v5.0.1+incompatible/go.mod h1:rbUlSV+CCpv/SuqUTP/8Bk2O3LyUV436/yaRGkhP6Z0=
 github.com/dlclark/regexp2 v1.1.6 h1:CqB4MjHw0MFCDj+PHHjiESmHX+N7t0tJzKvC6M97BRg=
 github.com/dlclark/regexp2 v1.1.6/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=

--- a/handler_factory.go
+++ b/handler_factory.go
@@ -1,29 +1,148 @@
 package krakend
 
 import (
-	botdetector "github.com/devopsfaith/krakend-botdetector/gin"
+	botdetector "github.com/devopsfaith/krakend-botdetector"
+	"github.com/devopsfaith/krakend-botdetector/krakend"
 	"github.com/devopsfaith/krakend-jose"
-	ginjose "github.com/devopsfaith/krakend-jose/gin"
-	lua "github.com/devopsfaith/krakend-lua/router/gin"
-	metrics "github.com/devopsfaith/krakend-metrics/gin"
-	opencensus "github.com/devopsfaith/krakend-opencensus/router/gin"
-	juju "github.com/devopsfaith/krakend-ratelimit/juju/router/gin"
+	muxjose "github.com/devopsfaith/krakend-jose/mux"
+	lua "github.com/devopsfaith/krakend-lua/router/mux"
+	metrics "github.com/devopsfaith/krakend-metrics/mux"
+	opencensus "github.com/devopsfaith/krakend-opencensus/router/mux"
+	krakendrate "github.com/devopsfaith/krakend-ratelimit"
+	"github.com/devopsfaith/krakend-ratelimit/juju"
+	jujurouter "github.com/devopsfaith/krakend-ratelimit/juju/router"
+	"github.com/devopsfaith/krakend/config"
 	"github.com/devopsfaith/krakend/logging"
-	router "github.com/devopsfaith/krakend/router/gin"
+	"github.com/devopsfaith/krakend/proxy"
+	"github.com/devopsfaith/krakend/router/httptreemux"
+	"github.com/devopsfaith/krakend/router/mux"
+	router "github.com/devopsfaith/krakend/router/mux"
+	"net/http"
+	"strings"
 )
 
 // NewHandlerFactory returns a HandlerFactory with a rate-limit and a metrics collector middleware injected
 func NewHandlerFactory(logger logging.Logger, metricCollector *metrics.Metrics, rejecter jose.RejecterFactory) router.HandlerFactory {
-	handlerFactory := juju.HandlerFactory
-	handlerFactory = lua.HandlerFactory(logger, handlerFactory)
-	handlerFactory = ginjose.HandlerFactory(handlerFactory, logger, rejecter)
+	handlerFactory := RateLimitHandlerFactory
+	handlerFactory = lua.HandlerFactory(logger, handlerFactory, httptreemux.ParamsExtractor)
+	handlerFactory = muxjose.HandlerFactory(handlerFactory, httptreemux.ParamsExtractor, logger, rejecter)
 	handlerFactory = metricCollector.NewHTTPHandlerFactory(handlerFactory)
 	handlerFactory = opencensus.New(handlerFactory)
-	handlerFactory = botdetector.New(handlerFactory, logger)
+	handlerFactory = NewBotDetector(handlerFactory, logger)
 	return handlerFactory
 }
 
 type handlerFactory struct{}
+
+// New checks the configuration and, if required, wraps the handler factory with a bot detector middleware
+func NewBotDetector(hf mux.HandlerFactory, l logging.Logger) mux.HandlerFactory {
+	return func(cfg *config.EndpointConfig, p proxy.Proxy) http.HandlerFunc {
+		next := hf(cfg, p)
+
+		detectorCfg, err := krakend.ParseConfig(cfg.ExtraConfig)
+		if err == krakend.ErrNoConfig {
+			l.Debug("botdetector: ", err.Error())
+			return next
+		}
+		if err != nil {
+			l.Warning("botdetector: ", err.Error())
+			return next
+		}
+
+		d, err := botdetector.New(detectorCfg)
+		if err != nil {
+			l.Warning("botdetector: unable to create the LRU detector:", err.Error())
+			return next
+		}
+		return BotDetectorhandler(d, next)
+	}
+}
+
+func BotDetectorhandler(f botdetector.DetectorFunc, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if f(r) {
+			http.Error(w, "bot rejected", http.StatusForbidden)
+			return
+		}
+
+		next(w, r)
+	}
+}
+
+// HandlerFactory is the out-of-the-box basic ratelimit handler factory using the default krakend endpoint
+// handler for the mux router
+var RateLimitHandlerFactory = NewRateLimiterMw(mux.CustomEndpointHandler(mux.NewRequestBuilder(httptreemux.ParamsExtractor)))
+
+// NewRateLimiterMw builds a rate limiting wrapper over the received handler factory.
+func NewRateLimiterMw(next mux.HandlerFactory) mux.HandlerFactory {
+	return func(remote *config.EndpointConfig, p proxy.Proxy) http.HandlerFunc {
+		handlerFunc := next(remote, p)
+
+		cfg := jujurouter.ConfigGetter(remote.ExtraConfig).(jujurouter.Config)
+		if cfg == jujurouter.ZeroCfg || (cfg.MaxRate <= 0 && cfg.ClientMaxRate <= 0) {
+			return handlerFunc
+		}
+
+		if cfg.MaxRate > 0 {
+			handlerFunc = NewEndpointRateLimiterMw(juju.NewLimiter(float64(cfg.MaxRate), cfg.MaxRate))(handlerFunc)
+		}
+		if cfg.ClientMaxRate > 0 {
+			switch strings.ToLower(cfg.Strategy) {
+			case "header":
+				handlerFunc = NewHeaderLimiterMw(cfg.Key, float64(cfg.ClientMaxRate), cfg.ClientMaxRate)(handlerFunc)
+			}
+		}
+		return handlerFunc
+	}
+}
+
+// EndpointMw is a function that decorates the received handlerFunc with some rateliming logic
+type EndpointMw func(http.HandlerFunc) http.HandlerFunc
+
+// NewEndpointRateLimiterMw creates a simple ratelimiter for a given handlerFunc
+func NewEndpointRateLimiterMw(tb juju.Limiter) EndpointMw {
+	return func(next http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			if !tb.Allow() {
+				http.Error(w, krakendrate.ErrLimited.Error(), 503)
+				return
+			}
+
+			next(w, r)
+		}
+	}
+}
+
+// NewHeaderLimiterMw creates a token ratelimiter using the value of a header as a token
+func NewHeaderLimiterMw(header string, maxRate float64, capacity int64) EndpointMw {
+	return NewTokenLimiterMw(HeaderTokenExtractor(header), juju.NewMemoryStore(maxRate, capacity))
+}
+
+// TokenExtractor defines the interface of the functions to use in order to extract a token for each request
+type TokenExtractor func(r *http.Request) string
+
+// HeaderTokenExtractor returns a TokenExtractor that looks for the value of the designed header
+func HeaderTokenExtractor(header string) TokenExtractor {
+	return func(r *http.Request) string { return r.Header.Get(header) }
+}
+
+// NewTokenLimiterMw returns a token based ratelimiting endpoint middleware with the received TokenExtractor and LimiterStore
+func NewTokenLimiterMw(tokenExtractor TokenExtractor, limiterStore krakendrate.LimiterStore) EndpointMw {
+	return func(next http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			tokenKey := tokenExtractor(r)
+			if tokenKey == "" {
+				http.Error(w, krakendrate.ErrLimited.Error(), http.StatusTooManyRequests)
+				return
+			}
+			if !limiterStore(tokenKey).Allow() {
+				http.Error(w, krakendrate.ErrLimited.Error(), http.StatusTooManyRequests)
+				return
+			}
+			next(w, r)
+		}
+	}
+}
 
 func (h handlerFactory) NewHandlerFactory(l logging.Logger, m *metrics.Metrics, r jose.RejecterFactory) router.HandlerFactory {
 	return NewHandlerFactory(l, m, r)

--- a/mux_botdetector.go
+++ b/mux_botdetector.go
@@ -1,0 +1,83 @@
+package krakend
+
+import (
+	botdetector "github.com/devopsfaith/krakend-botdetector"
+	"github.com/devopsfaith/krakend-botdetector/krakend"
+	"github.com/devopsfaith/krakend/config"
+	"github.com/devopsfaith/krakend/logging"
+	"github.com/devopsfaith/krakend/proxy"
+	"github.com/devopsfaith/krakend/router/mux"
+	"net/http"
+)
+
+// Register checks the configuration and, if required, registers a bot detector middleware at the gin engine
+func Register(cfg config.ExtraConfig, l logging.Logger, mw []mux.HandlerMiddleware) []mux.HandlerMiddleware {
+	detectorCfg, err := krakend.ParseConfig(cfg)
+	if err == krakend.ErrNoConfig {
+		l.Debug("botdetector middleware: ", err.Error())
+		return mw
+	}
+	if err != nil {
+		l.Warning("botdetector middleware: ", err.Error())
+		return mw
+	}
+	d, err := botdetector.New(detectorCfg)
+	if err != nil {
+		l.Warning("botdetector middleware: unable to createt the LRU detector:", err.Error())
+		return mw
+	}
+	return append(mw, middleware(d))
+}
+
+type Middleware struct {
+	f botdetector.DetectorFunc
+}
+
+func (hm *Middleware) Handler(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if hm.f(r) {
+			http.Error(w, "bot rejected", http.StatusForbidden)
+		}
+
+		h.ServeHTTP(w, r)
+	})
+}
+
+func middleware(f botdetector.DetectorFunc) mux.HandlerMiddleware {
+	return &Middleware{f: f}
+}
+
+// New checks the configuration and, if required, wraps the handler factory with a bot detector middleware
+func NewBotDetector(hf mux.HandlerFactory, l logging.Logger) mux.HandlerFactory {
+	return func(cfg *config.EndpointConfig, p proxy.Proxy) http.HandlerFunc {
+		next := hf(cfg, p)
+
+		detectorCfg, err := krakend.ParseConfig(cfg.ExtraConfig)
+		if err == krakend.ErrNoConfig {
+			l.Debug("botdetector: ", err.Error())
+			return next
+		}
+		if err != nil {
+			l.Warning("botdetector: ", err.Error())
+			return next
+		}
+
+		d, err := botdetector.New(detectorCfg)
+		if err != nil {
+			l.Warning("botdetector: unable to create the LRU detector:", err.Error())
+			return next
+		}
+		return BotDetectorhandler(d, next)
+	}
+}
+
+func BotDetectorhandler(f botdetector.DetectorFunc, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if f(r) {
+			http.Error(w, "bot rejected", http.StatusForbidden)
+			return
+		}
+
+		next(w, r)
+	}
+}

--- a/proxy_factory.go
+++ b/proxy_factory.go
@@ -4,7 +4,7 @@ import (
 	cel "github.com/devopsfaith/krakend-cel"
 	jsonschema "github.com/devopsfaith/krakend-jsonschema"
 	lua "github.com/devopsfaith/krakend-lua/proxy"
-	metrics "github.com/devopsfaith/krakend-metrics/gin"
+	metrics "github.com/devopsfaith/krakend-metrics/mux"
 	opencensus "github.com/devopsfaith/krakend-opencensus"
 	"github.com/devopsfaith/krakend/logging"
 	"github.com/devopsfaith/krakend/proxy"

--- a/router_engine.go
+++ b/router_engine.go
@@ -1,42 +1,21 @@
 package krakend
 
 import (
+	"github.com/devopsfaith/krakend/router/httptreemux"
+	orighttptreemux "github.com/dimfeld/httptreemux"
 	"io"
 
-	botdetector "github.com/devopsfaith/krakend-botdetector/gin"
-	httpsecure "github.com/devopsfaith/krakend-httpsecure/gin"
-	lua "github.com/devopsfaith/krakend-lua/router/gin"
 	"github.com/devopsfaith/krakend/config"
 	"github.com/devopsfaith/krakend/logging"
-	"github.com/gin-gonic/gin"
 )
 
 // NewEngine creates a new gin engine with some default values and a secure middleware
-func NewEngine(cfg config.ServiceConfig, logger logging.Logger, w io.Writer) *gin.Engine {
-	if !cfg.Debug {
-		gin.SetMode(gin.ReleaseMode)
-	}
-
-	engine := gin.New()
-	engine.Use(gin.LoggerWithConfig(gin.LoggerConfig{Output: w}), gin.Recovery())
-
-	engine.RedirectTrailingSlash = true
-	engine.RedirectFixedPath = true
-	engine.HandleMethodNotAllowed = true
-
-	if err := httpsecure.Register(cfg.ExtraConfig, engine); err != nil {
-		logger.Warning(err)
-	}
-
-	lua.Register(logger, cfg.ExtraConfig, engine)
-
-	botdetector.Register(cfg, logger, engine)
-
-	return engine
+func NewEngine(cfg config.ServiceConfig, logger logging.Logger, w io.Writer) httptreemux.Engine {
+	return httptreemux.NewEngine(orighttptreemux.NewContextMux())
 }
 
 type engineFactory struct{}
 
-func (e engineFactory) NewEngine(cfg config.ServiceConfig, l logging.Logger, w io.Writer) *gin.Engine {
+func (e engineFactory) NewEngine(cfg config.ServiceConfig, l logging.Logger, w io.Writer) httptreemux.Engine {
 	return NewEngine(cfg, l, w)
 }


### PR DESCRIPTION
Heya, this PR is mostly to get a discussion going.
I'd really like to add some kind of switch or option to use mux instead of gin, particularly because of the REST issues around it and seeing that the underlying router had this in the "coming soon" for 5 years.

This PR isn't ready to merge yet, but it successfully runs krakend and most of its features.

In order to get this in a mergeable state (from my POV) I want to get the following done:
- [ ] Upstream necessary changes into the plugins, particularly:
	- [ ] botdetector
	- [ ] rate-limiter
	- [ ] httpsecure (to align the methods with other plugins)
	- [ ] cors
- [ ] Move the mux and gin specific code into separate codepaths so that it's possible to switch between them
- [ ] Add a config entry or a separate command (like run-mux or run --mux) to switch to the mux based codepath
- [ ] Get someone with actual Go experience to look at the code, this is the first time I've ever seen it
- [ ] Fix or document missing features/issues, in particular:
	- [ ] error_alias straight up doesn't work
	- [ ] IP based ratelimiting isn't implemented (though I've already spotted a method for it)
	- [ ] influxdb (doesn't have any mux implementation at all)
	- [ ] Request logging doesn't seem to work, not sure why
	- [ ] Proxies don't seem to work
- [ ] Run some benchmarks and tests