### PR TITLE
Set the gelfWriter to nil if there's an error in gelf

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -287,7 +287,10 @@ func (LoggerBuilder) NewLogger(cfg config.ServiceConfig) (logging.Logger, io.Wri
 				return gologging.DefaultPattern
 			}
 		})
+	} else {
+		gelfWriter = nil
 	}
+
 	logger, gologgingErr := logstash.NewLogger(cfg.ExtraConfig)
 
 	if gologgingErr != nil {


### PR DESCRIPTION
since if you return an interface that have an underlying pointer it's never nil.