### PR TITLE
Add security scan for the repository

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,37 @@
+---
+name: security
+
+# Run for all pushes to master and pull requests when Go or YAML files change
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ master ]
+  schedule:
+    - cron: '23 20 * * 2'
+
+jobs:
+  security-repo-scan:
+    name: security-repo-scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 
+        uses: actions/checkout@v3
+      
+      - name: Run Trivy vulnerability scanner in repo mode
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          security-checks: 'vuln,secret'
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'HIGH,CRITICAL'
+          skip-dirs: 'tests'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
This does a security scan for hardcoded secrets and vulnerable software
dependencies. This will hopefully help us prioritize dependency updates
in such a way that we don't keep vulnerable dependencies for too long.
Note that this should only be detecting `HIGH` and `CRITICAL`
vulnerabilities as to not overwhelm the team with warnings.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
