### PR TITLE
Add security scanning to container images

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,3 +35,60 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: 'trivy-results.sarif'
+
+  image-scan:
+    strategy:
+      matrix:
+        config:
+          - image: krakend/builder
+            dockerfile: Dockerfile-builder
+          - image: krakend/krakend-ce
+            dockerfile: Dockerfile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 
+        uses: actions/checkout@v3
+
+      - name: Set the environment variables
+        run: |
+          echo "GOLANG_VERSION=$(grep -m 1 GOLANG_VERSION Makefile | sed 's/^.*= //g')" >> $GITHUB_ENV
+          echo "ALPINE_VERSION=$(grep -m 1 ALPINE_VERSION Makefile | sed 's/^.*= //g')" >> $GITHUB_ENV
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ matrix.config.image }}
+          tags: |
+            type=sha
+
+      - name: "Build image ${{ matrix.config.image }}"
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ${{ matrix.config.dockerfile }}
+          build-args: |
+            GOLANG_VERSION=${{ env.GOLANG_VERSION }}
+            ALPINE_VERSION=${{ env.ALPINE_VERSION }}
+          push: false
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Run Trivy vulnerability scanner in image mode
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'image'
+          image-ref: ${{ steps.meta.outputs.tags }}
+          security-checks: 'vuln,secret'
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'HIGH,CRITICAL'
+          skip-dirs: 'tests'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
This adds a step in the GitHub Actions CI to automatically build the
krakend-ce and builder images and run a security scan on them.

Similarly to the repository scans introduced in a previous PR [1], this
uses Trivy [2] to run the scans, which allows us to add exceptions if
vulnerabilities are not relevant to these images.

[1] https://github.com/krakendio/krakend-ce/pull/650
[2] https://aquasecurity.github.io/trivy/v0.35/

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
