### PR TITLE
Fixing glibc detection on macOS

### DIFF
--- a/find_glibc.sh
+++ b/find_glibc.sh
@@ -19,7 +19,7 @@ Linux*)
     fi
     ;;
 Darwin*)
-    GLIBC=DARWIN-$(sw_vers | grep ProductVersion | cut -d$'\t' -f2)
+    GLIBC=DARWIN-$(sw_vers | grep ProductVersion: | tr -s '\t' | cut -d$'\t' -f2)
     ;;
 *)
   ;;


### PR DESCRIPTION
Fixes #731 by grepping for `ProductVersion:` specifically and squeezing multiple tabs - if any. The script now returns `DARWIN-13.3.1` again, which seems sufficient since a  Rapid Security Response update most likely wouldn't introduce glibc incompatibilities.