### PR TITLE
Update to apline-3.18 based image to mitigate SSL3 CVE-2023-1255

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ DOCKER_WDIR := /tmp/fpm
 DOCKER_FPM := devopsfaith/fpm
 GOLANG_VERSION := 1.20.4
 GLIBC_VERSION := $(shell sh find_glibc.sh)
-ALPINE_VERSION := 3.17
+ALPINE_VERSION := 3.18
 OS_TAG :=
 EXTRA_LDFLAGS :=
 


### PR DESCRIPTION
A security scan of krakend-2.3.2 shows 6 security vulnerabilities.

These three don't have any fixes yet:

1. LOW: based on github.com/aws/aws-sdk-go [CVE-2020-8912](https://avd.aquasec.com/nvd/cve-2020-8912) 
2. MEDIUM: based on github.com/aws/aws-sdk-go [CVE-2020-8911](https://avd.aquasec.com/nvd/cve-2020-8911) 
3. MEDIUM: based on github.com/gin-gonic/gin [CVE-2023-29401](https://avd.aquasec.com/nvd/cve-2023-29401)

The three that can be mitigated now are:

4. MEDIUM: based on github.com/prometheus/prometheus [CVE-2019-3826](https://avd.aquasec.com/nvd/cve-2019-3826)

This shows a library version v0.40.5 which can be fixed in v2.7.1

The last two are the SSL3 vulnerability:

5. MEDIUM based on libcrypto3 [CVE-2023-1255](https://avd.aquasec.com/nvd/cve-2023-1255)
6. MEDIUM based on libssl3 [CVE-2023-1255](https://avd.aquasec.com/nvd/cve-2023-1255)

These exist in the base alpine-3.17 image.

Updating to alpine-3.18 for the base image fixes these last two SSL3 based vulnerabilities.