### PR TITLE
Remove old ratelimite alias so the middleware can be activated with t…

### DIFF
--- a/cmd/krakend-ce/main.go
+++ b/cmd/krakend-ce/main.go
@@ -67,8 +67,6 @@ var aliases = map[string]string{
 	"github.com/devopsfaith/krakend/proxy":                          "proxy",
 	"github_com/luraproject/lura/router/gin":                        "router",
 
-	"github.com/devopsfaith/krakend-ratelimit/juju/router":    "qos/ratelimit/router",
-	"github.com/devopsfaith/krakend-ratelimit/juju/proxy":     "qos/ratelimit/proxy",
 	"github.com/devopsfaith/krakend-httpcache":                "qos/http-cache",
 	"github.com/devopsfaith/krakend-circuitbreaker/gobreaker": "qos/circuit-breaker",
 


### PR DESCRIPTION
…he new namespace.